### PR TITLE
Add gemini and grok base

### DIFF
--- a/utils/logs-storage.ts
+++ b/utils/logs-storage.ts
@@ -14,7 +14,7 @@ export interface LogEntry {
     context: 'background' | 'content' | 'popup' | 'unknown';
 }
 
-export const MAX_LOGS = 1000;
+export const MAX_LOGS = 4000;
 const STORAGE_KEY = 'logs';
 export const FLUSH_INTERVAL_MS = 2000;
 export const FLUSH_THRESHOLD = 50;

--- a/utils/minimal-logs.ts
+++ b/utils/minimal-logs.ts
@@ -130,11 +130,9 @@ function isCriticalLine(line: string): boolean {
         line.includes('shouldProcessFinished') ||
         line.includes('handleConversationSwitch') ||
         line.includes('clearCanonicalStabilization') ||
-        line.includes('Readiness decision:') ||
-        line.includes('Button readiness transition') ||
         line.includes('Network source: marking canonical') ||
-        line.includes('Timeout: max retries') ||
-        line.includes('Timeout: elapsed exceeded')
+        line.includes('Conversation switch') ||
+        line.includes('Tab became visible')
     );
 }
 


### PR DESCRIPTION
Before updating the doc, here's my analysis of each issue and comparison with the other agents:

**A. GPT 5 Thinking Mini** - Working. One "degraded snapshot captured" toast is expected and correctly recovers to canonical-ready. All three agents agree.

**B. GPT 5.2 Thinking Background Tabs (Force Save)** - All three agents identify the core issue: background tabs have no recovery mechanism when the user switches back. The cascade is: stream completes while hidden → warm fetch 404 (auth missing) → DOM snapshot fails (Chrome throttles hidden tabs) → retries exhaust → degraded_manual_only → **no visibilitychange listener to re-attempt**. Claude-sonnet-4.5 and GPT-codex both recommend a `visibilitychange` listener. Gemini-3.0-pro suggests tick-counting instead of wall-clock checks, which is a valid secondary concern but not the primary fix.

**B2. Force Save user-only JSON** - All agents identify this: `handleSaveClick` doesn't try `requestPageSnapshot` before exporting. Since the tab is now visible, a fresh snapshot would succeed.

**B3. Debug report regression** - All agents identify the log spam from `hasCanonicalStabilizationTimedOut` and `resolveReadinessDecision` flooding the 1000-entry ring buffer. The `isCriticalLine` function makes it worse by including these spam lines. GPT-codex and Claude-sonnet both recommend deduplication and log level downgrades.

**C. Gemini 3.0** - Zero interceptor logs suggests the MAIN world fetch wrapper isn't being called. My additional finding: the interceptor IS configured for Gemini (in `SUPPORTED_PLATFORM_URLS`), and the `[DISCOVERY]` logging should catch ALL POST requests regardless of RPC ID drift. The fact that zero discovery messages appear means either: (1) the interceptor script fails silently before patching fetch, (2) Gemini uses a mechanism other than `window.fetch`/XHR, or (3) Gemini saves a reference to original `fetch` before the interceptor patches it. Need instrumentation to determine which.

**D/E. Grok (x.com and grok.com)** - The logs show `/2/grok/add_response.json` is the streaming endpoint, which is NOT matched by the current adapter patterns. The response is NDJSON format causing "Unexpected non-whitespace character after JSON" parse errors. The warm fetch returns 501 for `load-responses`. The `conversations_v2` and `response-node` URLs are matched but parsing fails because the adapter doesn't handle those response formats.

Now let me update the regression doc and start fixing everything TDD-style.

This is a large doc. Let me update it with the new regressions from this session.

Good. Now let me start fixing the issues, starting with P0 (log spam), then the background tab recovery and Force Save fix. I'll work TDD style.

## Fix 1: V2.1-022 — Log Spam + MAX_LOGS

The fix has three parts:
1. Gate `hasCanonicalStabilizationTimedOut` logger.info behind `timeoutWarningByAttempt`
2. Downgrade `resolveReadinessDecision` health-check logs from info to debug
3. Increase `MAX_LOGS` from 1000 to 4000

Now fix the log spam in `hasCanonicalStabilizationTimedOut` — gate behind `timeoutWarningByAttempt`:

Now downgrade the high-frequency `resolveReadinessDecision` logs from `logger.info` to `logger.debug`:

Now let me run the existing tests to make sure these changes don't break anything.

All 36 tests pass. Now let me also run the logs-storage tests:

Now let me fix the `isCriticalLine` function to exclude the spam patterns that were causing the minimal report to be filled with noise:

## Fix 2: V2.1-023 — Background Tab Recovery (visibilitychange) + V2.1-024 — Force Save Fresh Snapshot

Let me first write the TDD tests, then implement the fixes.

Now let me implement the `visibilitychange` listener. I'll add it after `cleanupButtonHealthCheck = registerButtonHealthCheck();` in the boot sequence:

Now add cleanup for the visibilitychange listener in the beforeunload handler:

Now fix V2.1-024: `handleSaveClick` should attempt `requestPageSnapshot` before the confirm dialog:

Now let me run the tests again to ensure nothing breaks:

All 36 tests still pass. Now let me check for lint errors:

Let me fix the lint errors in the visibilitychange handler:

All passing. Now let me move on to the Gemini and Grok fixes. Let me work on them in parallel using subagents.

Now let me look at the Grok adapter more carefully to understand the parsing issues, and the grok.com streaming endpoint.

Now I understand the grok.com issues clearly. The key problems are:

1. `/rest/app-chat/conversations/new` returns NDJSON but falls through to `JSON.parse` which fails
2. The `/2/grok/add_response.json` streaming endpoint for x.com/i/grok is not matched by any pattern
3. Warm fetch to `load-responses` returns HTTP 501

Let me fix these in the Grok adapter:

Now let me read the `parseInterceptedData` method to understand where to add the NDJSON handling:

Let me check what test data we have for grok.com streaming and what the NDJSON format looks like:

Let me look at the `apiEndpointPattern` and other patterns:

Now let me also look at how the x.com `/2/grok/add_response.json` endpoint works. Let me check the interceptor to see how it discovers URLs:

Let me look at the existing Grok tests and the x.com streaming format:

Let me pick up where we left off. I was mid-investigation on the Grok issues (V2.1-026/027) and Gemini (V2.1-025). Let me first review the AI agent analyses and the current state of the regression doc, then generate hypotheses and instrument.

Now let me read the analysis docs from the other AI agents and the interceptor code more carefully to generate complete hypotheses.

Let me now read the interceptor more deeply to understand the Gemini and Grok interception flow:

Let me now look at where the interceptor wraps fetch and what happens for Gemini:

Now let me look at the factory to understand how platform adapters are resolved for API URLs:

Now let me check the Gemini adapter's patterns:

Now let me check the WXT config for `matches` patterns:

Now let me check the interceptor's content script definition:

Now let me check the `export default` defineContentScript:

Good. Now I have a thorough understanding of all three issues. Let me generate hypotheses based on my code analysis and the AI agent analyses.

---

## Hypotheses

### V2.1-025: Gemini Interception Failure (5 hypotheses)

**H25-A**: Gemini 3.0 has changed its API transport. Instead of `fetch` POST to `/_/BardChatUi/data/batchexecute`, it now uses a different mechanism (WebSocket, EventSource/SSE, or a different fetch API path). The fetch wrapper never sees the requests.

**H25-B**: Gemini 3.0 has changed its URL structure. The path is no longer `/_/BardChatUi/data/batchexecute` — it may use a new path prefix or different endpoint entirely. Discovery logs would show this if the interceptor IS running, but the apiEndpointPattern wouldn't match.

**H25-C**: The interceptor's MAIN world init IS executing (confirmed by `__BLACKIYA_INTERCEPTED__` guard), but the `log()` function's `window.postMessage` is not being received by the ISOLATED world content script. The logs are being generated but lost.

**H25-D**: Gemini's page creates a dedicated Web Worker or Service Worker that makes the API calls, bypassing the MAIN world's wrapped `fetch` entirely.

**H25-E**: The interceptor wraps `fetch` at `document_start`, but Gemini caches a reference to the original `fetch` in a module closure BEFORE the content script has a chance to wrap it (race condition in module loading order).

### V2.1-026: grok.com Streaming (3 hypotheses)

**H26-A**: `/rest/app-chat/conversations/new` IS matched by `apiEndpointPattern` (`grok\.com\/rest\/app-chat\/conversations(_v2)?\/[^/]+`), but `parseInterceptedData` falls through to the generic `JSON.parse` fallback which fails on NDJSON. The fix is adding a dedicated handler before the generic fallback.

**H26-B**: Button flicker during reasoning is caused by `conversations_v2/{id}` returning metadata without messages (returns `null`), then streaming partial responses from `conversations/new` briefly enabling the button before the next partial chunk.

**H26-C**: The "Unexpected non-whitespace character after JSON" error is specifically from the NDJSON response hitting `JSON.parse` in the generic fallback at line 966.

### V2.1-027: x.com/grok Streaming (2 hypotheses)

**H27-A**: `/2/grok/add_response.json` is NOT matched by `apiEndpointPattern` (which only matches `/i/api/graphql/` paths and `grok.com` REST paths). It's only caught by discovery logging on POST.

**H27-B**: Even if we add the endpoint to the pattern, the NDJSON format (`{conversationId, ...}\n{result:{sender:...}}`) needs a new parser since it differs from both the GraphQL format and the grok.com REST format.

Now let me instrument the code to verify these hypotheses.

Now let me add debug instrumentation. I need to add fetch-based logging to the interceptor (MAIN world) that posts to the debug server, and also instrument the Grok adapter's `parseInterceptedData`.

First, let me revert the premature `isGrokComNewConversationEndpoint` function I added earlier (it's a fix, not instrumentation — we need evidence first):

Now let me instrument the interceptor. I'll add instrumentation for all hypotheses at once:

Good. Now let me add instrumentation. I'll add debug server fetch calls at critical points:

1. **Interceptor init** (H25-A through H25-E) - confirm interceptor is running
2. **Every fetch call on Gemini** (H25-A, H25-B) - see what URLs Gemini calls
3. **Grok parseInterceptedData entry** (H26-A, H26-C, H27-A) - log URL routing
4. **Grok generic JSON.parse fallback** (H26-A, H26-C) - log parse failures

Now add instrumentation inside the fetch wrapper to log ALL fetch calls on Gemini and Grok hosts:

Now add instrumentation inside `handleFetchInterception` to log API pattern matching results:

Now add instrumentation to the XHR handler for Gemini:

Now let me instrument the Grok adapter's `parseInterceptedData`:

Now instrument the generic JSON.parse fallback in Grok's `parseInterceptedData`:

Now let me also add instrumentation for the x.com `add_response.json` endpoint. The key question is whether it reaches `handleFetchInterception` at all, or if it's filtered out. Let me add a log in the discovery path that specifically catches this URL:

Good - the `handleFetchInterception` already logs API adapter match results via the agent log I added. The x.com `add_response.json` will show up as `apiAdapter: null` which confirms H27-A.

Now let me also add one more important instrumentation point: inside the Gemini fetch wrapper, log whether the `originalFetch` is actually being called (to detect H25-E - race condition where Gemini caches original fetch before wrapping):

Wait - the `fetch` call in the INIT log at line 1274 uses `fetch` BEFORE it's been wrapped! At this point, `window.fetch` is still the original. But wait, we just set `__BLACKIYA_INTERCEPTED__ = true`, and the init log is the next line. The `fetch` here is the original browser fetch. That's fine - it should work for the debug server.

But here's a potential issue: the init log at line 1274 calls `fetch` which is the ORIGINAL `window.fetch`. This is fine. But let me note that the instrumentation inside the fetch wrapper will call `fetch` which at that point is the WRAPPED fetch. This could cause infinite recursion! Let me fix this by using `originalFetch` instead.

Actually wait, looking more carefully: inside the wrapped fetch at line 1420+, I'm calling `fetch(...)` to send the debug log. But `window.fetch` has already been replaced with the wrapper. So calling `fetch(...)` inside the wrapper would recursively call the wrapper!

I need to use a reference to the original fetch for all debug logging inside the wrapper. Let me fix this:

I see - `originalFetch` is already captured at line 1287. I need to store a separate reference for debug logging and use it in my instrumentation calls. Let me add that:

Now replace all my `fetch(` debug calls inside the interceptor wrapper with `_dbgFetch(`:

Lines 1274 (INIT) uses the original fetch before wrapping, so that's fine. But lines 1105 and 1457 are inside the wrapped context. Line 1105 is inside `handleFetchInterception` which is a standalone function — it uses the global `fetch` which is now the wrapper. Line 1457 is inside the wrapped fetch itself. Both need to use `_dbgFetch`.

But `_dbgFetch` is a local variable inside `main()`. `handleFetchInterception` is defined outside of `main()`. I need to use a global reference. Let me use the window property:

Now fix the fetch wrapper instrumentation at line 1457 to use `_dbgFetch`:

Now for the Grok adapter's `parseInterceptedData`, the `fetch` calls there are fine since the Grok adapter runs in the ISOLATED world (content script), not the MAIN world. The ISOLATED world's `fetch` is never wrapped. So those calls are safe.

Let me verify the build works:

Build succeeds. Now let me also run the existing tests to make sure the instrumentation doesn't break anything:

All 48 Grok tests pass. Now let me clear the debug log file and ask the user to reproduce:

I've added debug instrumentation at 5 key points to test all 10 hypotheses across the three issues. Here's what I'm measuring:

**Instrumentation points:**
1. **Interceptor INIT** — Confirms MAIN world script executes (H25-ALL)
2. **Fetch wrapper** — Logs every POST/conversation/batchexecute fetch on Gemini/Grok/x.com (H25-A/B)
3. **Pattern matching** — Logs `apiEndpointPattern` match results for non-ChatGPT URLs (H25-A/B, H26-A, H27-A)
4. **Grok parseInterceptedData entry** — Logs which URL routing branch is taken (H26-A, H27-B)
5. **Grok generic JSON.parse fallback** — Logs parse failures with NDJSON detection (H26-A/C)

<reproduction_steps>
1. Reload the extension in `chrome://extensions/` (click the refresh icon on Blackiya) to pick up the new build from `dist/`.
2. Open 1 tab for **Gemini 3.0 Pro** (`gemini.google.com`), send a prompt, wait for the response to complete.
3. Open 1 tab for **grok.com**, send a prompt, wait for the response to complete.
4. Open 1 tab for **x.com/i/grok**, send a prompt, wait for the response to complete.
5. Wait about 10 seconds after all responses finish to ensure all async logs are captured.
</reproduction_steps>

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ✅ 3 no changes — [View all](https://hub.continue.dev/inbox?pr=https%3A%2F%2Fgithub.com%2Fragaeeb%2Fblackiya%2Fpull%2F8&utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->