### PR TITLE
H-01: Split attempt-id read vs write semantics

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "blackiya",
     "description": "Chrome extension to capture and save conversation JSON from ChatGPT and other LLMs",
     "private": true,
-    "version": "2.0.4",
+    "version": "2.0.5",
     "type": "module",
     "author": "Ragaeeb Haq",
     "license": "MIT",

--- a/utils/runner/attempt-registry.ts
+++ b/utils/runner/attempt-registry.ts
@@ -21,6 +21,40 @@ export interface ResolveRunnerAttemptIdResult {
     nextActiveAttemptId: string | null;
 }
 
+/**
+ * Pure read-only lookup: returns the existing attempt ID for a conversation
+ * or the current active attempt. Returns `null` if no attempt exists.
+ * Never creates a new attempt or signals mutation of activeAttemptId.
+ *
+ * Use this for logging, display, throttle-key lookups, and any other
+ * read-path that should NOT mutate runner state.
+ */
+export function peekRunnerAttemptId(input: {
+    conversationId?: string;
+    activeAttemptId: string | null;
+    attemptByConversation: Map<string, string>;
+    resolveAliasedAttemptId: (attemptId: string) => string;
+}): string | null {
+    const { conversationId, attemptByConversation, resolveAliasedAttemptId } = input;
+    if (conversationId) {
+        const mapped = attemptByConversation.get(conversationId);
+        if (mapped) {
+            return resolveAliasedAttemptId(mapped);
+        }
+    }
+    if (input.activeAttemptId) {
+        return resolveAliasedAttemptId(input.activeAttemptId);
+    }
+    return null;
+}
+
+/**
+ * Mutating resolve: returns the existing attempt ID or creates a new one.
+ * The caller MUST apply the `nextActiveAttemptId` side effect.
+ *
+ * Use this only for write paths that intentionally create or bind attempts
+ * (e.g., response-finished, stream-done probe setup, force-save recovery).
+ */
 export function resolveRunnerAttemptId(input: ResolveRunnerAttemptIdInput): ResolveRunnerAttemptIdResult {
     const { conversationId, attemptByConversation, resolveAliasedAttemptId } = input;
     if (conversationId) {

--- a/utils/runner/calibration-runner.ts
+++ b/utils/runner/calibration-runner.ts
@@ -1,4 +1,6 @@
-export type CalibrationStep = 'queue-flush' | 'passive-wait' | 'endpoint-retry' | 'page-snapshot';
+import type { CalibrationStep } from '@/utils/calibration-profile';
+
+export type { CalibrationStep };
 
 export function prioritizeCalibrationStep(step: CalibrationStep, defaultOrder: CalibrationStep[]): CalibrationStep[] {
     if (defaultOrder.includes(step)) {

--- a/utils/runner/readiness.ts
+++ b/utils/runner/readiness.ts
@@ -17,7 +17,7 @@ export interface ResolveRunnerReadinessInput {
     captureMeta: ExportMeta;
     sfeResolution: SfeConversationResolution;
     evaluateReadinessForData: (data: ConversationData) => PlatformReadiness;
-    resolveAttemptId: (conversationId: string) => string;
+    resolveAttemptId: (conversationId: string) => string | null;
     hasCanonicalStabilizationTimedOut: (attemptId: string) => boolean;
     emitTimeoutWarningOnce: (attemptId: string, conversationId: string) => void;
     clearTimeoutWarningByAttempt: (attemptId: string) => void;
@@ -111,12 +111,13 @@ export function resolveRunnerReadinessDecision(input: ResolveRunnerReadinessInpu
     input.clearCanonicalReadyLogStamp(input.conversationId);
 
     const attemptId = input.resolveAttemptId(input.conversationId);
-    const timeoutDecision = createTimeoutReadinessDecision(input, attemptId);
-    if (timeoutDecision) {
-        return timeoutDecision;
+    if (attemptId) {
+        const timeoutDecision = createTimeoutReadinessDecision(input, attemptId);
+        if (timeoutDecision) {
+            return timeoutDecision;
+        }
+        input.clearTimeoutWarningByAttempt(attemptId);
     }
-
-    input.clearTimeoutWarningByAttempt(attemptId);
 
     if (input.captureMeta.fidelity === 'degraded') {
         return {


### PR DESCRIPTION
#### ✅ **H-01: Split attempt-id read vs write semantics**
- **New:** peekRunnerAttemptId (pure, read-only) in [utils/runner/attempt-registry.ts](app://-/index.html#)
- **New:** [peekAttemptId](app://-/index.html#) wrapper in [utils/runner/index.ts](app://-/index.html#)
- **Migrated:** 7 read-only call sites to [peekAttemptId](app://-/index.html#) (logging, display, throttle keys, readiness)
- **Kept:** 7 write paths still use mutating [resolveAttemptId](app://-/index.html#)
- **Tests:** 5 unit tests + 1 integration test

#### ✅ **H-02: Calibration builder centralization**
- **New in [calibration-profile.ts](app://-/index.html#):** [CalibrationStep](app://-/index.html#) type, [strategyFromStep](app://-/index.html#)/[stepFromStrategy](app://-/index.html#) mappings, [buildCalibrationProfileFromStep](app://-/index.html#) (manual-strict policy)
- **Removed:** ~50 lines of duplicated inline builders from [runner/index.ts](app://-/index.html#) (buildCalibrationTimings, buildCalibrationRetry, [buildCalibrationProfile](app://-/index.html#))
- **Key design:** Manual-strict policy intentionally uses tighter domQuietWindow (800ms vs 1200ms for conservative) and always disables ['dom_hint', 'snapshot_fallback']
- **Tests:** 10 new characterization tests (3 mapping + 7 builder)

#### ✅ **H-05: Grok adapter state isolation**
- **New:** [GrokAdapterState](app://-/index.html#) class encapsulating conversationTitles, activeConversations, lastActiveConversationId
- **New:** [resetGrokAdapterState()](app://-/index.html#) exported for test isolation
- **Removed:** 3 bare module-level mutable variables (_lastActiveGrokComConversationId, conversationTitles, activeConversations)
- **Tests:** 2 state isolation tests (reset clears state, titles don't leak across resets)

### Docs Updated
- **[docs/handoff.md](app://-/index.html#)** — All three tasks marked ✅, execution plan reordered, noteworthy items updated
- **[docs/architecture.md](app://-/index.html#)** — Version bumped, calibration profile management documented, attempt-id read/write pattern documented, Grok state encapsulation documented, Current Gaps updated

### Remaining Work (next execution plan)
1. H-03 runner decomposition continuation
2. H-04 interceptor decomposition continuation
3. M-05 through M-09 (P2 performance/cleanup items)

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ✅ 3 no changes — [View all](https://hub.continue.dev/inbox/pr/ragaeeb/blackiya/25?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Comprehensive architectural refinements documenting improved state management patterns, calibration strategies, and component isolation.

* **Tests**
  * Substantially expanded test coverage ensuring enhanced reliability, state reset mechanisms, and cross-conversation stability.

* **Chores**
  * Version bumped to 2.0.5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->